### PR TITLE
add param 't' to let user decide how many files to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ $ spark-submit \
 --conf "spark.scheduler.minRegisteredResourcesRatio=1" \
 --conf "spark.scheduler.maxRegisteredResourcesWaitingTime=60s" \
 --conf "spark.executor.extraJavaOptions=-Dalluxio.user.block.size.bytes.default=128MB -Dalluxio.user.file.readtype.default=NO_CACHE -Dalluxio.user.file.writetype.default=MUST_CACHE" \
-benchmarks-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p 8 -s 6144 -o w -b alluxio://<MASTER_HOSTNAME>:19998/testdfsio/
+benchmarks-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p 8 -t 10 -s 6144 -o w -b alluxio
+://<MASTER_HOSTNAME>:19998/testdfsio/
 ```
 
 This will launch the `alluxio.benchmarks.TestDFSIO` job on the Spark cluster.
@@ -29,6 +30,8 @@ This will launch the `alluxio.benchmarks.TestDFSIO` job on the Spark cluster.
 This test takes the following parameters:
 * `-p <number of tasks>`: This controls the number of tasks to use for the test
 * `-s <size of write in MB>`: This is the size of the file to write for each task, in MB
+* `-t <number of files in each partition>`: This will generate 't*p' files in total, each
+ partition will generate 't' files
 * `-o <sequence of operations>`: This is a string of 'w' or 'r' which determine the test sequence. For example, `-o wwwwwrrrrr` means the test will do the write portion of the test 5 times, then do the read portion of the test 5 times. The output of the test will be 10 sets of results. 
 Note the read operation requires data to be written by write operation with same file size and number of partitions/tasks before. You can run write operation either in the same job before read or in a separate job before the read job.
 

--- a/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
+++ b/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
@@ -243,26 +243,22 @@ class TestDFSIO(private val partitions: Long,
     val data = generateBuffer()
 
     val writeRdd = sc.textFile(controlPath, partitions.toInt).map(x => {
-
+      val dataFile = basePath + x.trim()
       val startMs = System.currentTimeMillis()
-
-          val dataFile = basePath + x.trim()
-          var i = partitionSize
-          val outstream = FileSystem.get(new URI(dataFile), new Configuration()).create(new Path(dataFile))
-          try {
-            while (i > 0) {
-              outstream.write(data)
-              i -= 1
-            }
-          } finally {
-            outstream.close()
-          }
+      var i = partitionSize
+      val outstream = FileSystem.get(new URI(dataFile), new Configuration()).create(new Path(dataFile))
+      try {
+        while (i > 0) {
+          outstream.write(data)
+          i -= 1
+        }
+      } finally {
+        outstream.close()
+      }
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
       (partitionSize * TestDFSIO.MB, durationMs)
-
     })
-
     val startMs = System.currentTimeMillis()
     val taskData = writeRdd.collect()
     val stopMs = System.currentTimeMillis()
@@ -277,19 +273,17 @@ class TestDFSIO(private val partitions: Long,
 
       val startMs = System.currentTimeMillis()
       var totalBytesRead = 0L
-
-          val dataFile = basePath + x.trim()
-          val instream = FileSystem.get(new URI(dataFile), new Configuration()).open(new Path(dataFile))
-          try {
-            var bytesRead = instream.read(data)
-            while (bytesRead != -1) {
-              totalBytesRead += bytesRead
-              bytesRead = instream.read(data)
-            }
-          } finally {
-            instream.close()
-          }
-
+      val dataFile = basePath + x.trim()
+      val instream = FileSystem.get(new URI(dataFile), new Configuration()).open(new Path(dataFile))
+      try {
+        var bytesRead = instream.read(data)
+        while (bytesRead != -1) {
+          totalBytesRead += bytesRead
+          bytesRead = instream.read(data)
+        }
+      } finally {
+        instream.close()
+      }
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
       (totalBytesRead, durationMs)

--- a/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
+++ b/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
@@ -220,7 +220,7 @@ class TestDFSIO(private val partitions: Long,
       }
       t += 1
       }
-      1
+      1 * times
     })
 
     writeRdd.sum()
@@ -244,9 +244,9 @@ class TestDFSIO(private val partitions: Long,
 
     val writeRdd = sc.textFile(controlPath, partitions.toInt).map(x => {
       val dataFile = basePath + x.trim()
-      val startMs = System.currentTimeMillis()
       var i = partitionSize
       val outstream = FileSystem.get(new URI(dataFile), new Configuration()).create(new Path(dataFile))
+      val startMs = System.currentTimeMillis()
       try {
         while (i > 0) {
           outstream.write(data)
@@ -257,7 +257,7 @@ class TestDFSIO(private val partitions: Long,
       }
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
-      (times * partitionSize * TestDFSIO.MB, durationMs)
+      (partitionSize * TestDFSIO.MB, durationMs)
     })
     val startMs = System.currentTimeMillis()
     val taskData = writeRdd.collect()
@@ -270,11 +270,10 @@ class TestDFSIO(private val partitions: Long,
 
     val readRdd = sc.textFile(controlPath, partitions.toInt).map(x => {
       val data = new Array[Byte](TestDFSIO.MB.toInt)
-
-      val startMs = System.currentTimeMillis()
       var totalBytesRead = 0L
       val dataFile = basePath + x.trim()
       val instream = FileSystem.get(new URI(dataFile), new Configuration()).open(new Path(dataFile))
+      val startMs = System.currentTimeMillis()
       try {
         var bytesRead = instream.read(data)
         while (bytesRead != -1) {

--- a/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
+++ b/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
@@ -30,6 +30,7 @@ object TestDFSIO {
   // the sub directory for the data
   private val DATA_DIR = "data/"
   private val FILE_PREFIX = "part-"
+  private val TIMES_PREFIX = "-time-"
 
   private def getOptions(): Options = {
     OptionBuilder.isRequired()
@@ -56,11 +57,18 @@ object TestDFSIO {
     OptionBuilder.withDescription("operations to run ('w' for writes, 'r' for reads")
     val operationsOption = OptionBuilder.create("o")
 
+    OptionBuilder.isRequired()
+    OptionBuilder.hasArg()
+    OptionBuilder.withArgName("TIMES")
+    OptionBuilder.withDescription("How many times you want run")
+    val timesOption = OptionBuilder.create("t")
+
     new Options()
       .addOption(partitionsOption)
       .addOption(sizeOption)
       .addOption(basePathOption)
       .addOption(operationsOption)
+      .addOption(timesOption)
   }
 
   private def printUsage(): Unit = {
@@ -73,6 +81,7 @@ object TestDFSIO {
     var partitionSize = 0L
     var basePath = ""
     var operations = ""
+    var times = 0L
     try {
       val parser = new BasicParser()
       val cmdLine = parser.parse(getOptions(), args)
@@ -84,6 +93,7 @@ object TestDFSIO {
       partitionSize = cmdLine.getOptionValue("s").toLong
       basePath = cmdLine.getOptionValue("b")
       operations = cmdLine.getOptionValue("o")
+      times = cmdLine.getOptionValue("t").toLong
     } catch {
       case e: Exception => {
         printUsage()
@@ -97,15 +107,16 @@ object TestDFSIO {
     basePath = basePath + TEST_DIR
     println("new basePath: " + basePath)
     println("operations: " + operations)
+    println("times: " + times)
 
     val conf = new SparkConf().setAppName("DFSIO")
     val sc = new SparkContext(conf)
 
     val tester = new TestDFSIO(partitions, partitionSize, basePath)
 
-    tester.runOperations(sc, operations)
+    tester.runOperations(sc, operations, times)
 
-    Thread.sleep(60000)
+    Thread.sleep(10000)
 
     sc.stop()
   }
@@ -151,9 +162,9 @@ class TestDFSIO(private val partitions: Long,
     }
   }
 
-  def runOperations(sc: SparkContext, operations: String): Unit = {
+  def runOperations(sc: SparkContext, operations: String, times: Long): Unit = {
     operations.map(_ match {
-      case 'w' | 'W' => runWrite(sc)
+      case 'w' | 'W' => runWrite(sc, times)
       case 'r' | 'R' => runRead(sc)
       case _ => new Result("", 1.0, Array())
     }).foreach(println _)
@@ -194,10 +205,12 @@ class TestDFSIO(private val partitions: Long,
     line.getBytes()
   }
 
-  private def generateControlFiles(sc: SparkContext): Unit = {
+  private def generateControlFiles(sc: SparkContext, times: Long): Unit = {
     val writeRdd = sc.parallelize(0 until partitions.toInt, partitions.toInt).map(x => {
-      val dataRelativeFile = TestDFSIO.DATA_DIR + TestDFSIO.FILE_PREFIX + x
-      val controlFile = controlPath + TestDFSIO.FILE_PREFIX + x
+      var t = 0
+      while (t < times){
+      val dataRelativeFile = TestDFSIO.DATA_DIR + TestDFSIO.FILE_PREFIX + x + TestDFSIO.TIMES_PREFIX + t
+      val controlFile = controlPath + TestDFSIO.FILE_PREFIX + x + TestDFSIO.TIMES_PREFIX + t
       val outstream = FileSystem.get(new URI(controlFile), new Configuration())
         .create(new Path(controlFile))
       try {
@@ -205,13 +218,15 @@ class TestDFSIO(private val partitions: Long,
       } finally {
         outstream.close()
       }
+      t += 1
+      }
       1
     })
 
     writeRdd.sum()
   }
 
-  private def runWrite(sc: SparkContext): Result = {
+  private def runWrite(sc: SparkContext, times: Long): Result = {
     val fs = FileSystem.get(new URI(basePath), new Configuration())
     if (fs.exists(new Path(basePath))) {
       println("path exists, deleting existing folder: " + basePath)
@@ -223,28 +238,31 @@ class TestDFSIO(private val partitions: Long,
 
     Thread.sleep(2000)
 
-    generateControlFiles(sc)
+    generateControlFiles(sc, times)
 
     val data = generateBuffer()
 
     val writeRdd = sc.textFile(controlPath, partitions.toInt).map(x => {
-      val dataFile = basePath + x.trim()
+
       val startMs = System.currentTimeMillis()
 
-      var i = partitionSize
-      val outstream = FileSystem.get(new URI(dataFile), new Configuration()).create(new Path(dataFile))
-      try {
-        while (i > 0) {
-          outstream.write(data)
-          i -= 1
-        }
-      } finally {
-        outstream.close()
-      }
+          val dataFile = basePath + x.trim()
+          var i = partitionSize
+          val outstream = FileSystem.get(new URI(dataFile), new Configuration()).create(new Path(dataFile))
+          try {
+            while (i > 0) {
+              outstream.write(data)
+              i -= 1
+            }
+          } finally {
+            outstream.close()
+          }
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
       (partitionSize * TestDFSIO.MB, durationMs)
+
     })
+
     val startMs = System.currentTimeMillis()
     val taskData = writeRdd.collect()
     val stopMs = System.currentTimeMillis()
@@ -256,19 +274,22 @@ class TestDFSIO(private val partitions: Long,
 
     val readRdd = sc.textFile(controlPath, partitions.toInt).map(x => {
       val data = new Array[Byte](TestDFSIO.MB.toInt)
-      val dataFile = basePath + x.trim()
+
       val startMs = System.currentTimeMillis()
       var totalBytesRead = 0L
-      val instream = FileSystem.get(new URI(dataFile), new Configuration()).open(new Path(dataFile))
-      try {
-        var bytesRead = instream.read(data)
-        while (bytesRead != -1) {
-          totalBytesRead += bytesRead
-          bytesRead = instream.read(data)
-        }
-      } finally {
-        instream.close()
-      }
+
+          val dataFile = basePath + x.trim()
+          val instream = FileSystem.get(new URI(dataFile), new Configuration()).open(new Path(dataFile))
+          try {
+            var bytesRead = instream.read(data)
+            while (bytesRead != -1) {
+              totalBytesRead += bytesRead
+              bytesRead = instream.read(data)
+            }
+          } finally {
+            instream.close()
+          }
+
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
       (totalBytesRead, durationMs)

--- a/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
+++ b/src/main/scala/alluxio/benchmarks/TestDFSIO.scala
@@ -257,7 +257,7 @@ class TestDFSIO(private val partitions: Long,
       }
       val stopMs = System.currentTimeMillis()
       val durationMs = stopMs - startMs
-      (partitionSize * TestDFSIO.MB, durationMs)
+      (times * partitionSize * TestDFSIO.MB, durationMs)
     })
     val startMs = System.currentTimeMillis()
     val taskData = writeRdd.collect()


### PR DESCRIPTION
sometimes, user want to generate huge numbers of files to test  the performance of the storage, but  previous version could only generate the number of files with ‘p’. with new param ‘t’ , the tool will generate t * p files to meet the requirement of huge number of file.